### PR TITLE
ISLANDORA-1569: Fixes attempted logging on nonexistent objects

### DIFF
--- a/includes/db.inc
+++ b/includes/db.inc
@@ -41,7 +41,7 @@ function islandora_usage_stats_pid_to_db($pid) {
       ->execute();
   }
   else {
-    throw new Exception("islandora_usage_stats_pid_to_db(): Could not load '{$pid}' for logging.");
+    throw new Exception("Could not load '{$pid}' as Islandora object");
   }
 }
 

--- a/includes/db.inc
+++ b/includes/db.inc
@@ -35,9 +35,14 @@ function islandora_usage_stats_pid_id($pid) {
  */
 function islandora_usage_stats_pid_to_db($pid) {
   $object = islandora_object_load($pid);
-  return db_insert('islandora_usage_stats_objects')
-    ->fields(array('pid' => $pid, 'label' => $object->label))
-    ->execute();
+  if ($object) {
+    return db_insert('islandora_usage_stats_objects')
+      ->fields(array('pid' => $pid, 'label' => $object->label))
+      ->execute();
+  }
+  else {
+    throw new Exception("islandora_usage_stats_pid_to_db(): Could not load '{$pid}' for logging.");
+  }
 }
 
 /**

--- a/includes/db.inc
+++ b/includes/db.inc
@@ -33,7 +33,7 @@ function islandora_usage_stats_pid_id($pid) {
 /**
  * Gets the database id related to a PID.
  *
- * @throws Exception if the $pid cannot be loaded 
+ * @throws Exception if the $pid cannot be loaded.
  */
 function islandora_usage_stats_pid_to_db($pid) {
   $object = islandora_object_load($pid);

--- a/includes/db.inc
+++ b/includes/db.inc
@@ -32,6 +32,8 @@ function islandora_usage_stats_pid_id($pid) {
 
 /**
  * Gets the database id related to a PID.
+ *
+ * @throws Exception if the $pid cannot be loaded 
  */
 function islandora_usage_stats_pid_to_db($pid) {
   $object = islandora_object_load($pid);

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -29,10 +29,10 @@ function islandora_usage_stats_log_object_view(AbstractObject $object) {
           }
           catch (Exception $e) {
             watchdog_exception(
-              'islandora_usage_stats', 
-              $e, 
-              'Attempted load of %cmodel as cmodel of %obj', 
-              array('%cmodel' => $model, '%obj' => $object->id), 
+              'islandora_usage_stats',
+              $e,
+              'Attempted load of %cmodel as cmodel of %obj',
+              array('%cmodel' => $model, '%obj' => $object->id),
               WATCHDOG_ERROR);
           }
         }
@@ -47,10 +47,10 @@ function islandora_usage_stats_log_object_view(AbstractObject $object) {
         }
         catch (Exception $e) {
           watchdog_exception(
-            'islandora_usage_stats', 
-            $e, 
-            'Attempted load of %cmodel as parent collection of %obj', 
-            array('%cmodel' => $collection, '%obj' => $object->id), 
+            'islandora_usage_stats',
+            $e,
+            'Attempted load of %cmodel as parent collection of %obj',
+            array('%cmodel' => $collection, '%obj' => $object->id),
             WATCHDOG_ERROR);
         }
       }

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -17,21 +17,38 @@ function islandora_usage_stats_log_object_view(AbstractObject $object) {
     if (($last_viewed + variable_get('islandora_usage_stats_cooldown_seconds', 300)) < REQUEST_TIME) {
       module_load_include('inc', 'islandora_basic_collection', 'includes/utilities');
       module_load_include('inc', 'islandora_usage_stats', 'includes/db');
-      $pid_id = islandora_usage_stats_get_pid_id($object->id);
-      $object_access_id = islandora_usage_stats_object_view_to_db($pid_id);
+      try {
+        $pid_id = islandora_usage_stats_get_pid_id($object->id);
+        $object_access_id = islandora_usage_stats_object_view_to_db($pid_id);
+      }
+      catch (Exception $e) {
+        watchdog('islandora_usage_stats', $e->getMessage());
+      }
+
       // Log content models.
       $object = islandora_object_load($object->id);
       foreach ($object->models as $model) {
         if ($model != 'fedora-system:FedoraObject-3.0') {
-          $model_id = islandora_usage_stats_get_pid_id($model);
-          islandora_usage_stats_content_model_view_to_db($object_access_id, $model_id);
+          try {
+            $model_id = islandora_usage_stats_get_pid_id($model);
+            islandora_usage_stats_content_model_view_to_db($object_access_id, $model_id);
+          }
+          catch (Exception $e) {
+            watchdog('islandora_usage_stats', $e->getMessage());
+          }
         }
       }
+
       // Log parents.
       $collections = islandora_basic_collection_get_parent_pids($object);
       foreach ($collections as $collection) {
-        $collection_id = islandora_usage_stats_get_pid_id($collection);
-        islandora_usage_stats_collection_view_to_db($object_access_id, $collection_id);
+        try {
+          $collection_id = islandora_usage_stats_get_pid_id($collection);
+          islandora_usage_stats_collection_view_to_db($object_access_id, $collection_id);
+        }
+        catch (Exception $e) {
+          watchdog('islandora_usage_stats', $e->getMessage());
+        }
       }
       islandora_usage_stats_session_object_last_viewed_time($object->id, REQUEST_TIME);
     }

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -22,7 +22,7 @@ function islandora_usage_stats_log_object_view(AbstractObject $object) {
         $object_access_id = islandora_usage_stats_object_view_to_db($pid_id);
       }
       catch (Exception $e) {
-        watchdog('islandora_usage_stats', t('Error from islandora_usage_stats_pid_to_db(): PID recieved could not be loaded.'));
+        watchdog('islandora_usage_stats', 'Error: islandora_usage_stats_pid_to_db() could not load %pid', array('%pid' => $object->id), WATCHDOG_ERROR);
       }
 
       // Log content models.
@@ -34,7 +34,7 @@ function islandora_usage_stats_log_object_view(AbstractObject $object) {
             islandora_usage_stats_content_model_view_to_db($object_access_id, $model_id);
           }
           catch (Exception $e) {
-            watchdog('islandora_usage_stats', t('Error from islandora_usage_stats_pid_to_db(): PID recieved could not be loaded.'));
+            watchdog('islandora_usage_stats', 'Error: islandora_usage_stats_pid_to_db() could not load %pid', array('%pid' => $model), WATCHDOG_ERROR);
           }
         }
       }
@@ -47,7 +47,7 @@ function islandora_usage_stats_log_object_view(AbstractObject $object) {
           islandora_usage_stats_collection_view_to_db($object_access_id, $collection_id);
         }
         catch (Exception $e) {
-          watchdog('islandora_usage_stats', t('Error from islandora_usage_stats_pid_to_db(): PID recieved could not be loaded.'));
+          watchdog('islandora_usage_stats', 'Error: islandora_usage_stats_pid_to_db() could not load %pid', array('%pid' => $collection), WATCHDOG_ERROR);
         }
       }
       islandora_usage_stats_session_object_last_viewed_time($object->id, REQUEST_TIME);

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -17,16 +17,10 @@ function islandora_usage_stats_log_object_view(AbstractObject $object) {
     if (($last_viewed + variable_get('islandora_usage_stats_cooldown_seconds', 300)) < REQUEST_TIME) {
       module_load_include('inc', 'islandora_basic_collection', 'includes/utilities');
       module_load_include('inc', 'islandora_usage_stats', 'includes/db');
-      try {
-        $pid_id = islandora_usage_stats_get_pid_id($object->id);
-        $object_access_id = islandora_usage_stats_object_view_to_db($pid_id);
-      }
-      catch (Exception $e) {
-        watchdog('islandora_usage_stats', 'Error: islandora_usage_stats_pid_to_db() could not load %pid', array('%pid' => $object->id), WATCHDOG_ERROR);
-      }
+      $pid_id = islandora_usage_stats_get_pid_id($object->id);
+      $object_access_id = islandora_usage_stats_object_view_to_db($pid_id);
 
       // Log content models.
-      $object = islandora_object_load($object->id);
       foreach ($object->models as $model) {
         if ($model != 'fedora-system:FedoraObject-3.0') {
           try {
@@ -34,7 +28,12 @@ function islandora_usage_stats_log_object_view(AbstractObject $object) {
             islandora_usage_stats_content_model_view_to_db($object_access_id, $model_id);
           }
           catch (Exception $e) {
-            watchdog('islandora_usage_stats', 'Error: islandora_usage_stats_pid_to_db() could not load %pid', array('%pid' => $model), WATCHDOG_ERROR);
+            watchdog_exception(
+              'islandora_usage_stats', 
+              $e, 
+              'Attempted load of %cmodel as cmodel of %obj', 
+              array('%cmodel' => $model, '%obj' => $object->id), 
+              WATCHDOG_ERROR);
           }
         }
       }
@@ -47,7 +46,12 @@ function islandora_usage_stats_log_object_view(AbstractObject $object) {
           islandora_usage_stats_collection_view_to_db($object_access_id, $collection_id);
         }
         catch (Exception $e) {
-          watchdog('islandora_usage_stats', 'Error: islandora_usage_stats_pid_to_db() could not load %pid', array('%pid' => $collection), WATCHDOG_ERROR);
+          watchdog_exception(
+            'islandora_usage_stats', 
+            $e, 
+            'Attempted load of %cmodel as parent collection of %obj', 
+            array('%cmodel' => $collection, '%obj' => $object->id), 
+            WATCHDOG_ERROR);
         }
       }
       islandora_usage_stats_session_object_last_viewed_time($object->id, REQUEST_TIME);

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -22,7 +22,7 @@ function islandora_usage_stats_log_object_view(AbstractObject $object) {
         $object_access_id = islandora_usage_stats_object_view_to_db($pid_id);
       }
       catch (Exception $e) {
-        watchdog('islandora_usage_stats', $e->getMessage());
+        watchdog('islandora_usage_stats', t('Error from islandora_usage_stats_pid_to_db(): PID recieved could not be loaded.'));
       }
 
       // Log content models.
@@ -34,7 +34,7 @@ function islandora_usage_stats_log_object_view(AbstractObject $object) {
             islandora_usage_stats_content_model_view_to_db($object_access_id, $model_id);
           }
           catch (Exception $e) {
-            watchdog('islandora_usage_stats', $e->getMessage());
+            watchdog('islandora_usage_stats', t('Error from islandora_usage_stats_pid_to_db(): PID recieved could not be loaded.'));
           }
         }
       }
@@ -47,7 +47,7 @@ function islandora_usage_stats_log_object_view(AbstractObject $object) {
           islandora_usage_stats_collection_view_to_db($object_access_id, $collection_id);
         }
         catch (Exception $e) {
-          watchdog('islandora_usage_stats', $e->getMessage());
+          watchdog('islandora_usage_stats', t('Error from islandora_usage_stats_pid_to_db(): PID recieved could not be loaded.'));
         }
       }
       islandora_usage_stats_session_object_last_viewed_time($object->id, REQUEST_TIME);


### PR DESCRIPTION
**JIRA Ticket**: [ISLANDORA-1569](https://jira.duraspace.org/browse/ISLANDORA-1569_

# What does this Pull Request do?
Throws an exception from `islandora_usage_stats_pid_to_db()` in includes/db.inc when it is passed the PID of a nonexistent object. Exception is caught in `islandora_usage_stats_log_object_view()` in includes/utilities.inc and logs a watchdog error.

# How should this be tested?
The main cause of the original error most likely came from stale RELS-EXT data, such as an object still saying that it is a member of a parent collection that no longer exists. I tested this by running the following code in a Devel "Execute PHP" block on a fresh Vagrant VM:
```php
// Loads 'islandora:video_collection' and adds fake parent collection
$object = islandora_object_load('islandora:video_collection');
$object->relationships->add(FEDORA_RELS_EXT_URI, 'isMemberOfCollection', 'islandora:fakecollection');

// Log a view on 'islandora:video_collection' which triggers indirect logging of fake parent
module_load_include('inc', 'islandora_usage_stats', 'includes/utilities');
islandora_usage_stats_log_object_view($object);
```

When executing this code against the 7.x branch, it produces the error described in [ISLANDORA-1569](https://jira.duraspace.org/browse/ISLANDORA-1569): 
`Notice: Trying to get property of non-object in islandora_usage_stats_pid_to_db() (line 39 of /var/www/html/archivesII/sites/all/modules/islandora_usage_stats/includes/db.inc).`

When executing this code against this PR, it should not give a visible error message on the page and instead log an error via watchdog.

# Additional Notes:
This is the first time I've ever dealt with exceptions in PHP so there's a fair chance I'm doing it wrong. 

# Interested parties
@willtp87 @DiegoPino 