### PR TITLE
Address 7.x-ISLANDORA-2170.

### DIFF
--- a/includes/db.inc
+++ b/includes/db.inc
@@ -340,7 +340,7 @@ function islandora_usage_stats_object_view_to_db($pid_id, $request_time = NULL, 
  * Write a content model view to the DB.
  */
 function islandora_usage_stats_content_model_view_to_db($object_access_id, $model_id) {
-  db_insert('islandora_usage_stats_content_model_access_log')->fields(array(
+  return db_insert('islandora_usage_stats_content_model_access_log')->fields(array(
     'object_access_id' => $object_access_id,
     'content_model' => $model_id,
   ))->execute();
@@ -350,7 +350,7 @@ function islandora_usage_stats_content_model_view_to_db($object_access_id, $mode
  * Write a collection view to the DB.
  */
 function islandora_usage_stats_collection_view_to_db($object_access_id, $collection_id) {
-  db_insert('islandora_usage_stats_collection_access_log')->fields(array(
+  return db_insert('islandora_usage_stats_collection_access_log')->fields(array(
     'object_access_id' => $object_access_id,
     'collection' => $collection_id,
   ))->execute();
@@ -375,7 +375,7 @@ function islandora_usage_stats_collection_view_to_db($object_access_id, $collect
  */
 function islandora_usage_stats_datastream_download_to_db($ds_id, $request_time = NULL, $ip_address = NULL, $uid = NULL) {
   global $user;
-  db_insert('islandora_usage_stats_object_ds_access_log')->fields(array(
+  return db_insert('islandora_usage_stats_object_ds_access_log')->fields(array(
     'ds_id' => $ds_id,
     'time' => ($request_time !== NULL) ? $request_time : REQUEST_TIME,
     'ip' => ($ip_address !== NULL) ? $ip_address : ip_address(),

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -47,7 +47,7 @@ function islandora_usage_stats_log_object_view(AbstractObject $object) {
         try {
           $collection_id = islandora_usage_stats_get_pid_id($collection);
           islandora_usage_stats_collection_view_to_db($object_access_id, $collection_id);
-          module_invoke_all('islandora_usage_stats_access_recorded', 'collection', $collection_id);
+          module_invoke_all('islandora_usage_stats_access_recorded', 'parent_collection', $collection_id);
         }
         catch (Exception $e) {
           watchdog_exception(

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -20,15 +20,17 @@ function islandora_usage_stats_log_object_view(AbstractObject $object) {
       $pid_id = islandora_usage_stats_get_pid_id($object->id);
       $object_access_id = islandora_usage_stats_object_view_to_db($pid_id);
 
-      module_invoke_all('islandora_usage_stats_access_recorded', 'object', $object_access_id, $pid_id, $object->id);
+      module_invoke_all('islandora_usage_stats_object_access_recorded', $object_access_id, $pid_id, $object->id);
 
       // Log content models.
       foreach ($object->models as $model) {
         if ($model != 'fedora-system:FedoraObject-3.0') {
           try {
             $model_id = islandora_usage_stats_get_pid_id($model);
-            islandora_usage_stats_content_model_view_to_db($object_access_id, $model_id);
-            module_invoke_all('islandora_usage_stats_access_recorded', 'cmodel', $model_id);
+            $model_access_id = islandora_usage_stats_content_model_view_to_db($object_access_id, $model_id);
+            module_invoke_all('islandora_usage_stats_cmodel_access_recorded', $model_access_id, $model_id, $model, $object->id);
+            $model_for_hook_name = preg_replace('/:/', '_', strtolower($model));
+            module_invoke_all('islandora_usage_stats_' . $model_for_hook_name . '_access_recorded', $model_access_id, $model_id, $model, $object->id);
           }
           catch (Exception $e) {
             watchdog_exception(
@@ -46,8 +48,8 @@ function islandora_usage_stats_log_object_view(AbstractObject $object) {
       foreach ($collections as $collection) {
         try {
           $collection_id = islandora_usage_stats_get_pid_id($collection);
-          islandora_usage_stats_collection_view_to_db($object_access_id, $collection_id);
-          module_invoke_all('islandora_usage_stats_access_recorded', 'parent_collection', $collection_id);
+          $collection_access_id = islandora_usage_stats_collection_view_to_db($object_access_id, $collection_id);
+          module_invoke_all('islandora_usage_stats_collection_access_recorded', $collection_access_id, $collection_id, $collection, $object_access_id, $object->id);
         }
         catch (Exception $e) {
           watchdog_exception(
@@ -77,8 +79,8 @@ function islandora_usage_stats_log_datastream_download($pid, $dsid) {
       module_load_include('inc', 'islandora_usage_stats', 'includes/db');
       islandora_usage_stats_log_object_view(islandora_object_load($pid));
       $ds_dsid = islandora_usage_stats_get_ds_dsid($pid, $dsid);
-      module_invoke_all('islandora_usage_stats_access_recorded', 'ds', $ds_dsid);
-      islandora_usage_stats_datastream_download_to_db($ds_dsid);
+      $datastream_download_id = islandora_usage_stats_datastream_download_to_db($ds_dsid);
+      module_invoke_all('islandora_usage_stats_datastream_download_recorded', $datastream_download_id, $ds_dsid, $pid, $dsid);
       islandora_usage_stats_session_datastream_last_viewed_time($pid, $dsid, REQUEST_TIME);
     }
   }

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -20,12 +20,15 @@ function islandora_usage_stats_log_object_view(AbstractObject $object) {
       $pid_id = islandora_usage_stats_get_pid_id($object->id);
       $object_access_id = islandora_usage_stats_object_view_to_db($pid_id);
 
+      module_invoke_all('islandora_usage_stats_access_recorded', 'object', $object_access_id, $pid_id, $object->id);
+
       // Log content models.
       foreach ($object->models as $model) {
         if ($model != 'fedora-system:FedoraObject-3.0') {
           try {
             $model_id = islandora_usage_stats_get_pid_id($model);
             islandora_usage_stats_content_model_view_to_db($object_access_id, $model_id);
+            module_invoke_all('islandora_usage_stats_access_recorded', 'cmodel', $model_id);
           }
           catch (Exception $e) {
             watchdog_exception(
@@ -44,6 +47,7 @@ function islandora_usage_stats_log_object_view(AbstractObject $object) {
         try {
           $collection_id = islandora_usage_stats_get_pid_id($collection);
           islandora_usage_stats_collection_view_to_db($object_access_id, $collection_id);
+          module_invoke_all('islandora_usage_stats_access_recorded', 'collection', $collection_id);
         }
         catch (Exception $e) {
           watchdog_exception(
@@ -73,6 +77,7 @@ function islandora_usage_stats_log_datastream_download($pid, $dsid) {
       module_load_include('inc', 'islandora_usage_stats', 'includes/db');
       islandora_usage_stats_log_object_view(islandora_object_load($pid));
       $ds_dsid = islandora_usage_stats_get_ds_dsid($pid, $dsid);
+      module_invoke_all('islandora_usage_stats_access_recorded', 'ds', $ds_dsid);
       islandora_usage_stats_datastream_download_to_db($ds_dsid);
       islandora_usage_stats_session_datastream_last_viewed_time($pid, $dsid, REQUEST_TIME);
     }

--- a/islandora_usage_stats.api.php
+++ b/islandora_usage_stats.api.php
@@ -1,25 +1,89 @@
 <?php
 /**
  * @file
- * This file documents all available hook functions to manipulate data.
+ * This file documents all available hook functions.
  */
 
 /**
- * Notify modules that the given access event was persisted.
+ * Notify modules that the given object access event was persisted.
  *
- * This hook is called after the event was persisted to the database. If the
- * attempt to persist the event failed, 
- *
- * @param string $type
- *   One of 'object', 'parent_collection', 'cmodel', 'ds'.
  * @param int $access_id
- *   The database ID resulting from persisting the entry to the database.
- *   If the attempt to persist the record failed, this will be NULL.
+ *   The id from the islandora_usage_stats_object_access_log table.
  * @param int $pid_id
- *   For object access events, the ID of the row recording the event.
+ *   The pid_id from the islandora_usage_stats_object_access_log table.
  * @param string $pid
- *   For object access events, the object's PID.
+ *   The PID of the object that was accessed.
  */
-function hook_islandora_usage_stats_access_recorded($type, $access_id, $pid_id = NULL, $pid = NULL);
+function hook_islandora_usage_stats_object_access_recorded($access_id, $pid_id, $pid) {
+
+}
+
+/**
+ * Notify modules that the given collection access event was persisted.
+ *
+ * @param int $access_id
+ *   The id from the islandora_usage_stats_collection_access_log table.
+ * @param int $collection_id
+ *   The collection's ID from the islandora_usage_stats_collection_access_log
+ *   table.
+ * @param string $collection_pid
+ *   The PID of the collection object that is the parent of the object accessed.
+ * @param int $object_access_id
+ *   The object_access_id from the islandora_usage_stats_object_access_log
+ *   table.
+ * @param int $pid
+ *   The PID of the object just accessed.
+ */
+function hook_islandora_usage_stats_collection_access_recorded($access_id, $collection_id, $collection_pid, $object_access_id, $pid) {
+
+}
+
+/**
+ * Notify modules that the given datastream download event was persisted.
+ *
+ * @param int $download_id
+ *   The id from the islandora_usage_stats_object_ds_access_log table.
+ * @param int $ds_dsid
+ *   The ds_dsid from the islandora_usage_stats_object_ds_access_log table.
+ * @param string $pid
+ *   The PID of the object the downloaded datastream belongs to.
+ * @param string $dsid
+ *   The DSID of the datastream that was downloaded.
+ */
+function hook_islandora_usage_stats_datastream_download_recorded($download_id, $ds_dsid, $pid, $dsid) {
+
+}
+
+/**
+ * Notify modules that the given content model access event was persisted.
+ *
+ * @param string $access_id
+ *   The id from the islandora_usage_stats_content_model_access_log table.
+ * @param int $cmodel_id
+ *   The content model's id in the 
+ *   islandora_usage_stats_content_model_access_log table.
+ * @param string $cmodel_pid
+ *   The PID of the content model that was accessed.
+ * @param string $pid
+ *   The PID of the object that was accessed.
+ */
+function hook_islandora_usage_stats_cmodel_access_recorded($access_id, $cmodel_id, $cmodel_pid, $pid);
+
+}
+
+/**
+ * Notify modules that the given content model access event was persisted.
+ *
+ * @param string $access_id
+ *   The id from the islandora_usage_stats_content_model_access_log table.
+ * @param string $cmodel_pid
+ *   The PID of the content model that was accessed.
+ * @param int $cmodel_id
+ *   The content model's id in the 
+ *   islandora_usage_stats_content_model_access_log table.
+ * @param string $pid
+ *   The PID of the object that was accessed.
+ */
+function hook_islandora_usage_stats_cmodel_pid_access_recorded($access_id, $cmodel_pid, $cmodel_id, $pid);
 
 }

--- a/islandora_usage_stats.api.php
+++ b/islandora_usage_stats.api.php
@@ -67,7 +67,7 @@ function hook_islandora_usage_stats_datastream_download_recorded($download_id, $
  * @param string $pid
  *   The PID of the object that was accessed.
  */
-function hook_islandora_usage_stats_cmodel_access_recorded($access_id, $cmodel_id, $cmodel_pid, $pid);
+function hook_islandora_usage_stats_cmodel_access_recorded($access_id, $cmodel_id, $cmodel_pid, $pid) {
 
 }
 
@@ -84,6 +84,6 @@ function hook_islandora_usage_stats_cmodel_access_recorded($access_id, $cmodel_i
  * @param string $pid
  *   The PID of the object that was accessed.
  */
-function hook_islandora_usage_stats_cmodel_pid_access_recorded($access_id, $cmodel_pid, $cmodel_id, $pid);
+function hook_islandora_usage_stats_cmodel_pid_access_recorded($access_id, $cmodel_pid, $cmodel_id, $pid) {
 
 }

--- a/islandora_usage_stats.api.php
+++ b/islandora_usage_stats.api.php
@@ -11,14 +11,14 @@
  * attempt to persist the event failed, 
  *
  * @param string $type
- *   One of 'object', 'collection', 'cmodel', 'ds'.
+ *   One of 'object', 'parent_collection', 'cmodel', 'ds'.
  * @param int $access_id
  *   The database ID resulting from persisting the entry to the database.
  *   If the attempt to persist the record failed, this will be NULL.
  * @param int $pid_id
  *   For object access events, the ID of the row recording the event.
  * @param string $pid
- *   For object access events, the objec't PID.
+ *   For object access events, the object's PID.
  */
 function hook_islandora_usage_stats_access_recorded($type, $access_id, $pid_id = NULL, $pid = NULL);
 

--- a/islandora_usage_stats.api.php
+++ b/islandora_usage_stats.api.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * @file
+ * This file documents all available hook functions to manipulate data.
+ */
+
+/**
+ * Notify modules that the given access event was persisted.
+ *
+ * This hook is called after the event was persisted to the database. If the
+ * attempt to persist the event failed, 
+ *
+ * @param string $type
+ *   One of 'object', 'collection', 'cmodel', 'ds'.
+ * @param int $access_id
+ *   The database ID resulting from persisting the entry to the database.
+ *   If the attempt to persist the record failed, this will be NULL.
+ * @param int $pid_id
+ *   For object access events, the ID of the row recording the event.
+ * @param string $pid
+ *   For object access events, the objec't PID.
+ */
+function hook_islandora_usage_stats_access_recorded($type, $access_id, $pid_id = NULL, $pid = NULL);
+
+}


### PR DESCRIPTION
**JIRA Ticket**: (https://jira.duraspace.org/browse/ISLANDORA-2170)

# What does this Pull Request do?

Defines hooks to notify modules that the given object, collection, content model access event was persisted, and that a datastream download event was persisted.

# What's new?

Fires the new hooks immediately after the functions that persist the object access, collection access, content model access, and datastream download are fired. Passes into the hook the relevant data to allow for useful logic within hook implementations.

Also, `islandora_usage_stats_object_view_to_db()` currently returns the id of the row added to record the object access, but the corresponding functions for content model, collection, and datastream downloads don't:

* `islandora_usage_stats_content_model_view_to_db()`
* `islandora_usage_stats_collection_view_to_db()`
* `islandora_usage_stats_datastream_download_to_db()`

I have changed these functions so they now do return their respective row IDs. Since the return value of these functions was never checked (it would have been `false`), there should be no side effects from adding a return value.

# How should this be tested?

1. At `admin/islandora/tools/islandora_usage_stats`, make sure "Omit IPs" is emtpy and "Cooldown time" is 0.
1. Install and enable https://github.com/mjordan/islandora_2170_test, which implements all of the new hooks. This module adds a `dsm()` that shows the values available for object, collection, and content model access events For datastream access, it doesn't fire `dsm()`, it fires `dd()`.
1. After you have enabled the test module, visit a non-collection object page. You should see three messages, one for each of object, collection, and content model access events.
  * If you view a basic image object, you will see a fourth dsm message that only displays for basic images.
1. To test datastream downloads, attempt to download the object's TN datastream at `http://localhost:8000/islandora/object/{mypid}/datastream/TN/download`. The results will be in `/tmp/drupal_debug.txt`.

# Additional Notes:

* Does this change require documentation to be updated? No, it includes an .api.php file for developers.
* Does this change add any new dependencies? No.
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? No.
* Could this change impact execution of existing code? No.

# Interested parties
@bryjbrown, @Islandora/7-x-1-x-committers
