### PR TITLE
ISLANDORA-2179: Makes regex for bot exclusion configurable

### DIFF
--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -186,6 +186,7 @@ function islandora_usage_stats_admin_form_submit($form, &$form_state) {
       variable_set('islandora_usage_stats_ip_list', $form_state['values']['islandora_usage_stats_ip_list']);
       variable_set('islandora_usage_stats_cooldown_seconds', $form_state['values']['islandora_usage_stats_cooldown_seconds']);
       variable_set('islandora_usage_stats_exclude_bots', $form_state['values']['islandora_usage_stats_exclude_bots']);
+      variable_set('islandora_usage_stats_exclude_bots_regex', $form_state['values']['islandora_usage_stats_exclude_bots_regex']);
       drupal_set_message(
         t("The configuration options have been saved.")
       );

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -44,6 +44,13 @@ function islandora_usage_stats_admin_form() {
     '#default_value' => variable_get('islandora_usage_stats_exclude_bots', '1'),
   );
 
+  $form['usage']['islandora_usage_stats_exclude_bots_regex'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Bot Exclusion Regex'),
+    '#description' => t('The regular expression used to filter out bots'),
+    '#default_value' => variable_get('islandora_usage_stats_exclude_bots_regex', '/bot|rambler|spider|crawl|slurp|curl|^$/i'),
+  );
+
   $form['clear'] = array(
     '#type' => 'fieldset',
     '#title' => t('Clear values'),

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -49,6 +49,7 @@ function islandora_usage_stats_admin_form() {
     '#title' => t('Bot Exclusion Regex'),
     '#description' => t('The regular expression used to filter out bots'),
     '#default_value' => variable_get('islandora_usage_stats_exclude_bots_regex', '/bot|rambler|spider|crawl|slurp|curl|^$/i'),
+    '#maxlength' => 256,
   );
 
   $form['clear'] = array(

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -124,8 +124,8 @@ function islandora_usage_stats_should_not_log() {
   }
   // Bots check here.
   if (variable_get('islandora_usage_stats_exclude_bots', 1)) {
-    // @todo: make agent regex configurable.
-    if (1 === preg_match('/bot|rambler|spider|crawl|slurp|curl|^$/i', $_SERVER['HTTP_USER_AGENT'])) {
+    $bot_regex = variable_get('islandora_usage_stats_exclude_bots_regex', '/bot|rambler|spider|crawl|slurp|curl|^$/i');
+    if (1 === preg_match($bot_regex, $_SERVER['HTTP_USER_AGENT'])) {
       return TRUE;
     }
   }

--- a/islandora_usage_stats.install
+++ b/islandora_usage_stats.install
@@ -13,6 +13,7 @@ function islandora_usage_stats_uninstall() {
     'islandora_usage_stats_ip_list',
     'islandora_usage_stats_cooldown_seconds',
     'islandora_usage_stats_exclude_bots',
+    'islandora_usage_stats_exclude_bots_regex',
     'islandora_usage_stats_top_downloads_block_display_rows',
     'islandora_usage_stats_top_search_block_display_rows',
   );


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-2179

# What does this Pull Request do?
Makes the regex used to filter out bots from usage stats counts configurable from the admin page.

# What's new?
A new field in the admin page for setting the excluded bot regex set to a new variable, and a check to that variable in the actual bot exclusion code.

# How should this be tested?
I actually have no idea.

# Additional Notes:
Any additional information that you think would be helpful when reviewing this PR.

# Interested parties
@mjordan @DiegoPino @rosiel @bondjimbond 