### PR TITLE
7.x Documentation - README explains what module does?

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,20 +2,20 @@
 
 ## Introduction
 
-A module for Drupal 7 to track views and downloads of Islandora items. Features include:
+A module to track views and downloads of Islandora items. Features include:
 
-* Toggle to ignore common bots
-* View count uses session variables and defaults to a 5 minute cooldown for repeated requests
-* Access log for all views and downloads
+* Toggle to ignore common bots, with a configurable regex bot filter
+* View count uses session variables, and defaults to a 5 minute cooldown for repeated requests
 * IP Exclusion list to prevent artificially inflating counts while testing/developing/administrating
 * Several customizable blocks to display metrics
-* Report generating interface
+* Report-generating interface at __Reports > Islandora Usage Stats Reports__
 * Object log views integration
+* Access log for all views and downloads
 
 Note:
 
-* Does **not** respect XACML or namespace restrictions.
-* This is a server-side tracking solution, as such a caching layer could impact it.  If this is impacting you a [solution](https://github.com/discoverygarden/islandora_ga_reports) using JavaScript may work better.
+* This module, and the views/blocks it generates, does **not** respect XACML or namespace restrictions.
+* As this is a server-side tracking solution, a caching layer could prevent accesses from being recorded.  If this is impacting you a [solution](https://github.com/discoverygarden/islandora_ga_reports) using JavaScript may work better.
 
 ## Requirements
 
@@ -31,13 +31,26 @@ This module requires the following modules/libraries:
 
 ## Installation
 
-Install as usual, see [this](https://drupal.org/documentation/install/modules-themes/modules-7) for further information.
+Install as usual, see [this](https://www.drupal.org/docs/7/extend/installing-modules) for further information.
+
+## Usage
+
+Usage stats for the children of a collection appear on the overview pages ("Manage" tab) of collections, to users who have the permission to "__View Islandora Usage Collection Overview__". A block showing the same information, __Usage Stats for Collections__, is also available under __Structure > Blocks__, which can be placed and permissioned like a normal block.
+
+A view of all gathered stats, with the ability to generate CSV reports, is available at __Reports > Islandora Usage Stats__ (`admin/reports/islandora_usage_stats_report`) for users who have the permission "__View Islandora Usage Reports__".
+
+This module also provides several Drupal blocks. They can be configured (e.g. number of rows to display, which PIDs to omit, ...) at __Structure > Blocks__:
+* __Most Searched Terms__
+* __Most Viewed Islandora Items__
+* __Recently Accessed Islandora Items__
+* __Recently Downloaded__
+
 
 ## Configuration
 
 Configuration options are available at Islandora » Islandora Utility Modules » Islandora Usage Stats Settings (admin/islandora/tools/islandora_usage_stats).
 
-![Configuration](https://raw.githubusercontent.com/wiki/islandora/islandora_usage_stats/images/usage_stats_configuration.jpg)
+![Configuration](https://user-images.githubusercontent.com/1943338/41436826-3bab2b9a-6ff9-11e8-96f9-7819388c40ee.png)
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -2,15 +2,15 @@
 
 ## Introduction
 
-A module to track views and downloads of Islandora items. Features include:
+A module that tracks views and downloads of Islandora items, using the Drupal database.
+
+Features include:
 
 * Toggle to ignore common bots, with a configurable regex bot filter
 * View count uses session variables, and defaults to a 5 minute cooldown for repeated requests
 * IP Exclusion list to prevent artificially inflating counts while testing/developing/administrating
-* Several customizable blocks to display metrics
-* Report-generating interface at __Reports > Islandora Usage Stats Reports__
-* Object log views integration
-* Access log for all views and downloads
+* Logs all views and datastream downloads
+* Views integration
 
 Note:
 
@@ -29,22 +29,25 @@ This module requires the following modules/libraries:
 * [Datepicker](https://www.drupal.org/project/datepicker)
 * [Views Data Export](https://www.drupal.org/project/views_data_export)
 
+This module can be extended with:
+
+* Views UI (bundled with Views)
+* [Islandora Usage Stats Callbacks](https://github.com/Islandora-Labs/islandora_usage_stats_callbacks) (in Islandora Labs)
+
+
 ## Installation
 
 Install as usual, see [this](https://www.drupal.org/docs/7/extend/installing-modules) for further information.
 
 ## Usage
 
-Usage stats for the children of a collection appear on the overview pages ("Manage" tab) of collections, to users who have the permission to "__View Islandora Usage Collection Overview__". A block showing the same information, __Usage Stats for Collections__, is also available under __Structure > Blocks__, which can be placed and permissioned like a normal block.
+Out of the box, Islandora usage stats provides:
+* views of usage stats on Collection overview pages
+* A report-generating interface at __Reports > Islandora Usage Stats Reports__
+* Several customizable blocks to display the most popular objects
+* A customizable block to show collection usage stats
 
-A view of all gathered stats, with the ability to generate CSV reports, is available at __Reports > Islandora Usage Stats__ (`admin/reports/islandora_usage_stats_report`) for users who have the permission "__View Islandora Usage Reports__".
-
-This module also provides several Drupal blocks. They can be configured (e.g. number of rows to display, which PIDs to omit, ...) at __Structure > Blocks__:
-* __Most Searched Terms__
-* __Most Viewed Islandora Items__
-* __Recently Accessed Islandora Items__
-* __Recently Downloaded__
-
+The data collected by Islandora Usage Stats is made available to Views, so custom reports can also be created.
 
 ## Configuration
 


### PR DESCRIPTION
Documentation update for 7.x-1.11

# What does this Pull Request do?

Rewrites the README

# What's new?

I tried to document how to use this module. It's confusing, and I need help! 

# Do you use Usage Stats?

I'm still not clear on the following:

1. What's the intended/most common method of using this module? 

1. The feature list mentions a  "Report-generating interface" -- is this indeed the view at Reports > Islandora Usage Stats Reports?

1. The feature list says it has "Object log views integration". What does this mean? 

1. The feature list says it has an "Access log for all views and downloads". Where is this log? 

I mean, maybe all of these refer to the fact that it adds six new (undocumented!) types of Views, that you can create at will?

5. And there was a paragraph in the Wiki that I deleted because I believe it to be false; can anyone confirm whether this is accurate? 

> Islandora Usage Stats collects each view of the object, where a person browses to the web interface for the object, and each download of each datastream associated with that object. Islandora might not provide a download button for all objects. For example, if you don't have a "Download" button for Videos on your Islandora site, then download counts will not be collected for a Video object.

> When a download or a view is recorded, this information is added to information about the object. All that Islandora does is to add 1 to a view count or download count. There isn't any IP information nor any information about the date and time. Therefore, it is not possible to pull a report by fiscal year or to scope statistics by date.


# Interested parties
@Islandora/7-x-1-x-committers And tagging known implementers: @bryjbrown @bondjimbond @mjordan 
