### PR TITLE
Documentation pass on the 7.x branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ This module requires the following modules/libraries:
 * [Date](https://www.drupal.org/project/date)
 * [Datepicker](https://www.drupal.org/project/datepicker)
 
-This module can be extended with:
+This module can be extended with the following Islandora community/Drupal contrib modules:
 
 * Views UI (bundled with Views)
 * [Islandora Usage Stats Callbacks](https://github.com/Islandora-Labs/islandora_usage_stats_callbacks) (in Islandora Labs)

--- a/README.md
+++ b/README.md
@@ -2,32 +2,32 @@
 
 ## Introduction
 
-A module that tracks views and downloads of Islandora items, using the Drupal database.
+A module that tracks views and downloads of Islandora items, as well as solr searches, in the Drupal database.
 
 Features include:
 
-* Toggle to ignore common bots, with a configurable regex bot filter
-* View count uses session variables, and defaults to a 5 minute cooldown for repeated requests
-* IP Exclusion list to prevent artificially inflating counts while testing/developing/administrating
-* Logs all views and datastream downloads
+* ability to ignore common bots, with a configurable regex bot filter
+* ability to ignore repeated requests based on session variables, with a default cooldown period of 5 minutes
+* ability to ignore requests from specific IP addresses for testing/developing/administration
 * Views integration
 
-Note:
+Islandora Usage Stats provides the back-end framework and gathers usage data, which can be exposed through custom Views or additional modules. It also provides some built-in tools for exposing usage information.
+
+Caution:
 
 * This module, and the views/blocks it generates, does **not** respect XACML or namespace restrictions.
-* As this is a server-side tracking solution, a caching layer could prevent accesses from being recorded.  If this is impacting you a [solution](https://github.com/discoverygarden/islandora_ga_reports) using JavaScript may work better.
+* As this is a server-side tracking solution, a caching layer can prevent usage from being accurately recorded.  If this is impacting you a [solution using JavaScript](https://github.com/discoverygarden/islandora_ga_reports) may work better.
 
 ## Requirements
 
 This module requires the following modules/libraries:
 
-* [Tuque](https://github.com/islandora/tuque)
 * [Islandora](https://github.com/islandora/islandora)
 * [Islandora basic collection](https://github.com/Islandora/islandora_solution_pack_collection)
-* [Views (3.x)](https://www.drupal.org/project/views)
+* [Views](https://www.drupal.org/project/views)
+* [Views Data Export](https://www.drupal.org/project/views_data_export)
 * [Date](https://www.drupal.org/project/date)
 * [Datepicker](https://www.drupal.org/project/datepicker)
-* [Views Data Export](https://www.drupal.org/project/views_data_export)
 
 This module can be extended with:
 
@@ -41,13 +41,14 @@ Install as usual, see [this](https://www.drupal.org/docs/7/extend/installing-mod
 
 ## Usage
 
-Out of the box, Islandora usage stats provides:
-* views of usage stats on Collection overview pages
-* A report-generating interface at __Reports > Islandora Usage Stats Reports__
+The data collected by Islandora Usage Stats is made available to Views, so custom reports can be created. It also works with community modules such as [Islandora Usage Stats Callbacks](https://github.com/Islandora-Labs/islandora_usage_stats_callbacks) to provide more functionality. 
+
+Out of the box, Islandora usage stats can also provide:
+* Views of usage stats on Collection overview pages
+* A View of object page views at __Reports > Islandora Usage Stats Reports__
 * Several customizable blocks to display the most popular objects
 * A customizable block to show collection usage stats
 
-The data collected by Islandora Usage Stats is made available to Views, so custom reports can also be created.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Islandora Usage Stats provides the back-end framework and gathers usage data, wh
 Caution:
 
 * This module, and the views/blocks it generates, does **not** respect XACML or namespace restrictions.
-* As this is a server-side tracking solution, a caching layer can prevent usage from being accurately recorded.  If this is impacting you a [solution using JavaScript](https://github.com/discoverygarden/islandora_ga_reports) may work better.
+* As this is a server-side tracking solution, a caching layer can prevent usage from being accurately recorded.  If this is impacting you, a solution using JavaScript may work better for you. Community solutions include [discoverygarden's Google Analytics module](https://github.com/discoverygarden/islandora_ga_reports) and [Diego Pino's Matomo module](https://github.com/DiegoPino/islandora_piwik/). 
 
 ## Requirements
 
@@ -33,6 +33,7 @@ This module can be extended with:
 
 * Views UI (bundled with Views)
 * [Islandora Usage Stats Callbacks](https://github.com/Islandora-Labs/islandora_usage_stats_callbacks) (in Islandora Labs)
+* [Islandora Usage Stats Charts](https://github.com/mjordan/islandora_usage_stats_charts) (by Mark Jordan)
 
 
 ## Installation
@@ -41,7 +42,7 @@ Install as usual, see [this](https://www.drupal.org/docs/7/extend/installing-mod
 
 ## Usage
 
-The data collected by Islandora Usage Stats is made available to Views, so custom reports can be created. It also works with community modules such as [Islandora Usage Stats Callbacks](https://github.com/Islandora-Labs/islandora_usage_stats_callbacks) to provide more functionality. 
+The data collected by Islandora Usage Stats is made available to Views, so custom reports can be created. It also works with community modules such as [Islandora Usage Stats Callbacks](https://github.com/Islandora-Labs/islandora_usage_stats_callbacks) or [Islandora Usage Stats Charts](https://github.com/mjordan/islandora_usage_stats_charts) to provide more functionality. These modules are not part of Islandora's official releases.
 
 Out of the box, Islandora usage stats can also provide:
 * Views of usage stats on Collection overview pages


### PR DESCRIPTION
**What's this change?** 

There's now a little more in the readme to emphasize this is a module that does back-end data collection and you probably want to use it with other modules (_callbacks) or make your own Views.

Also mention that it logs solr searches.

See also #64.

component mgr @willtp87, release mgrs @bryjbrown @bondjimbond, doc mgr @DonRichards 